### PR TITLE
Update topic names and frame/link names to match ouster ROS driver

### DIFF
--- a/ouster_description/rviz/example.rviz
+++ b/ouster_description/rviz/example.rviz
@@ -58,11 +58,11 @@ Visualization Manager:
           Value: true
         base_link:
           Value: true
-        os1_imu:
+        os_imu:
           Value: true
-        os1_lidar:
+        os_lidar:
           Value: true
-        os1_sensor:
+        os_sensor:
           Value: true
       Marker Scale: 1
       Name: TF
@@ -72,10 +72,10 @@ Visualization Manager:
       Tree:
         base_footprint:
           base_link:
-            os1_sensor:
-              os1_imu:
+            os_sensor:
+              os_imu:
                 {}
-              os1_lidar:
+              os_lidar:
                 {}
       Update Interval: 0
       Value: true
@@ -98,15 +98,15 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
-        os1_imu:
+        os_imu:
           Alpha: 1
           Show Axes: false
           Show Trail: false
-        os1_lidar:
+        os_lidar:
           Alpha: 1
           Show Axes: false
           Show Trail: false
-        os1_sensor:
+        os_sensor:
           Alpha: 1
           Show Axes: false
           Show Trail: false
@@ -142,7 +142,7 @@ Visualization Manager:
       Size (Pixels): 3
       Size (m): 0.009999999776482582
       Style: Flat Squares
-      Topic: /os1_cloud_node/points
+      Topic: /os_cloud_node/points
       Unreliable: false
       Use Fixed Frame: true
       Use rainbow: true

--- a/ouster_description/tests/os1_gazebo.test
+++ b/ouster_description/tests/os1_gazebo.test
@@ -8,7 +8,7 @@
    </include>
 
    <test test-name="os1GazeboHzTest_points" pkg="rostest" type="hztest" name="pointsHz">
-      <param name="topic" value="/os1_cloud_node/points" />
+      <param name="topic" value="/ouster/points" />
       <param name="hz" value="10" />
       <param name="hzerror" value="9" />
       <param name="test_duration" value="10.0" />
@@ -16,7 +16,7 @@
    </test>
 
    <test test-name="os1GazeboHzTest_imu" pkg="rostest" type="hztest" name="imuHz">
-      <param name="topic" value="/os1_cloud_node/imu" />
+      <param name="topic" value="/ouster/imu" />
       <param name="hz" value="100" />
       <param name="hzerror" value="50" />
       <param name="test_duration" value="10.0" />

--- a/ouster_description/urdf/OS1-64.urdf.xacro
+++ b/ouster_description/urdf/OS1-64.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="OS1-64">
   <xacro:property name="M_PI" value="3.1415926535897931" />
-  <xacro:macro name="OS1-64" params="*origin parent:=base_link name:=os1_sensor topic_points:=/os1_cloud_node/points topic_imu:=/os1_cloud_node/imu hz:=10 lasers:=64 samples:=512 min_range:=0.9 max_range:=75.0 noise:=0.008 min_angle:=-${M_PI} max_angle:=${M_PI} lidar_link:=os1_lidar imu_link:=os1_imu vfov_min:=-.26 vfov_max:=.26">
+  <xacro:macro name="OS1-64" params="*origin parent:=base_link name:=os_sensor topic_points:=/ouster/points topic_imu:=/ouster/imu hz:=10 lasers:=64 samples:=512 min_range:=0.9 max_range:=75.0 noise:=0.008 min_angle:=-${M_PI} max_angle:=${M_PI} lidar_link:=os_lidar imu_link:=os_imu vfov_min:=-.26 vfov_max:=.26">
 
     <joint name="${name}_mount_joint" type="fixed">
       <xacro:insert_block name="origin" />

--- a/ouster_description/worlds/os-1-64.world
+++ b/ouster_description/worlds/os-1-64.world
@@ -13,7 +13,7 @@
 
     <model name="os-1-64">
       <!-- Give the base link a unique name -->
-      <link name="os1_lidar">
+      <link name="os_lidar">
 
         <pose>0 0 0.0365 0 0 0</pose>
 


### PR DESCRIPTION
Currently, the URDF file(s) in this package use `os1_` in frame ids and link names, as well as `/os1_cloud_node` for topic namespaces. However, the `ouster_ros` ROS driver publishes data to hardcoded `os_` for frame ids and link names (https://github.com/ouster-lidar/ouster-ros/blob/master/src/os_cloud_nodelet.cpp#L40), and `ouster` for topic namespaces (https://github.com/ouster-lidar/ouster-ros/blob/master/launch/sensor.launch#L3). This discrepancy causes issues when trying to view data in `rviz`, since the URDF/tf does not align with the frame id(s) where data is actually being published.